### PR TITLE
Add Authorization Details JSON input to Request Credential form

### DIFF
--- a/web/src/admin/IdentityDetails.vue
+++ b/web/src/admin/IdentityDetails.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
     <h1>Identity: {{ $route.params.subjectID }}</h1>
-    <ErrorMessage v-if="requestCredentialError" :title="'Credential request failed'" :message="requestCredentialError"/>
+    <ErrorMessage v-if="requestCredentialError" title="Credential request failed">
+      <div class="font-mono text-xs uppercase tracking-wide">{{ requestCredentialError }}</div>
+      <div v-if="formattedRequestCredentialErrorDescription" class="whitespace-pre-line mt-2">{{ formattedRequestCredentialErrorDescription }}</div>
+    </ErrorMessage>
     <ErrorMessage v-if="fetchError" :message="fetchError"/>
     <div v-if="details">
       <section>
@@ -138,10 +141,19 @@ export default {
     return {
       fetchError: undefined,
       requestCredentialError: undefined,
+      requestCredentialErrorDescription: undefined,
       details: undefined,
       shownDIDDocument: undefined,
       discoveryServices: {},
       credentialProfiles: [],
+    }
+  },
+  computed: {
+    formattedRequestCredentialErrorDescription() {
+      if (!this.requestCredentialErrorDescription) {
+        return ''
+      }
+      return this.requestCredentialErrorDescription.replace(/, ([a-zA-Z]+):/g, '\n$1:')
     }
   },
   created() {
@@ -161,7 +173,8 @@ export default {
       if (!error) {
         return
       }
-      this.requestCredentialError = errorDescription ? `${error}: ${errorDescription}` : error
+      this.requestCredentialError = error
+      this.requestCredentialErrorDescription = errorDescription
 
       if (searchParams.has('error') || searchParams.has('error_description')) {
         searchParams.delete('error')

--- a/web/src/admin/IdentityDetails.vue
+++ b/web/src/admin/IdentityDetails.vue
@@ -153,12 +153,29 @@ export default {
       this.$emit('statusUpdate', event)
     },
     captureRedirectError() {
-      const {error, error_description, ...rest} = this.$route.query
+      // OAuth-compliant issuers put error params in the URL's query component (window.location.search),
+      // which is outside the hash-router's view. Check both locations.
+      const searchParams = new URLSearchParams(window.location.search)
+      const error = searchParams.get('error') || this.$route.query.error
+      const errorDescription = searchParams.get('error_description') || this.$route.query.error_description
       if (!error) {
         return
       }
-      this.requestCredentialError = error_description ? `${error}: ${error_description}` : error
-      this.$router.replace({name: this.$route.name, params: this.$route.params, query: rest})
+      this.requestCredentialError = errorDescription ? `${error}: ${errorDescription}` : error
+
+      if (searchParams.has('error') || searchParams.has('error_description')) {
+        searchParams.delete('error')
+        searchParams.delete('error_description')
+        const newSearch = searchParams.toString()
+        const newUrl = window.location.pathname + (newSearch ? '?' + newSearch : '') + window.location.hash
+        window.history.replaceState(window.history.state, '', newUrl)
+      }
+      if (this.$route.query.error || this.$route.query.error_description) {
+        const rest = Object.fromEntries(
+            Object.entries(this.$route.query).filter(([k]) => k !== 'error' && k !== 'error_description')
+        )
+        this.$router.replace({name: this.$route.name, params: this.$route.params, query: rest})
+      }
     },
     fetchData() {
       this.$api.get('api/config')

--- a/web/src/admin/IdentityDetails.vue
+++ b/web/src/admin/IdentityDetails.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <h1>Identity: {{ $route.params.subjectID }}</h1>
+    <ErrorMessage v-if="requestCredentialError" :title="'Credential request failed'" :message="requestCredentialError"/>
     <ErrorMessage v-if="fetchError" :message="fetchError"/>
     <div v-if="details">
       <section>
@@ -136,6 +137,7 @@ export default {
   data() {
     return {
       fetchError: undefined,
+      requestCredentialError: undefined,
       details: undefined,
       shownDIDDocument: undefined,
       discoveryServices: {},
@@ -143,11 +145,20 @@ export default {
     }
   },
   created() {
+    this.captureRedirectError()
     this.fetchData()
   },
   methods: {
     updateStatus(event) {
       this.$emit('statusUpdate', event)
+    },
+    captureRedirectError() {
+      const {error, error_description, ...rest} = this.$route.query
+      if (!error) {
+        return
+      }
+      this.requestCredentialError = error_description ? `${error}: ${error_description}` : error
+      this.$router.replace({name: this.$route.name, params: this.$route.params, query: rest})
     },
     fetchData() {
       this.$api.get('api/config')

--- a/web/src/admin/credentials/RequestCredential.vue
+++ b/web/src/admin/credentials/RequestCredential.vue
@@ -53,6 +53,7 @@ export default {
       selectedWalletDID: '',
       authorizationDetails: '',
       authorizationDetailsError: undefined,
+      authorizationDetailsPlaceholder: '[{"type": "openid_credential", ...}]',
       issueError: undefined,
       credentialProfiles: [],
       walletDIDs: [],
@@ -61,9 +62,11 @@ export default {
   computed: {
     subjectID() {
       return this.$route.params.subjectID
-    },
-    authorizationDetailsPlaceholder() {
-      return '[{"type": "openid_credential", ...}]'
+    }
+  },
+  watch: {
+    authorizationDetails() {
+      this.authorizationDetailsError = undefined
     }
   },
   created() {
@@ -125,6 +128,17 @@ export default {
           parsedAuthorizationDetails = JSON.parse(trimmedAuthorizationDetails)
         } catch (e) {
           this.authorizationDetailsError = 'Invalid JSON: ' + e.message
+          return
+        }
+        if (!Array.isArray(parsedAuthorizationDetails)) {
+          this.authorizationDetailsError = 'Authorization Details must be a JSON array'
+          return
+        }
+        const nonObject = parsedAuthorizationDetails.find(
+            entry => entry === null || typeof entry !== 'object' || Array.isArray(entry)
+        )
+        if (nonObject !== undefined) {
+          this.authorizationDetailsError = 'Each Authorization Details entry must be a JSON object'
           return
         }
       }

--- a/web/src/admin/credentials/RequestCredential.vue
+++ b/web/src/admin/credentials/RequestCredential.vue
@@ -28,6 +28,14 @@
         <label>Issuer</label>
         <p>{{ getIssuerForType(selectedCredentialType) }}</p>
       </div>
+      <details>
+        <summary>Authorization Details (JSON)</summary>
+        <textarea v-model="authorizationDetails"
+                  rows="8"
+                  :placeholder="authorizationDetailsPlaceholder"
+                  spellcheck="false"></textarea>
+        <p v-if="authorizationDetailsError" class="text-red-500 text-sm">{{ authorizationDetailsError }}</p>
+      </details>
     </div>
   </modal-window>
 </template>
@@ -43,6 +51,8 @@ export default {
     return {
       selectedCredentialType: '',
       selectedWalletDID: '',
+      authorizationDetails: '',
+      authorizationDetailsError: undefined,
       issueError: undefined,
       credentialProfiles: [],
       walletDIDs: [],
@@ -51,6 +61,9 @@ export default {
   computed: {
     subjectID() {
       return this.$route.params.subjectID
+    },
+    authorizationDetailsPlaceholder() {
+      return '[{"type": "openid_credential", ...}]'
     }
   },
   created() {
@@ -93,6 +106,7 @@ export default {
     },
     issueCredential() {
       this.issueError = undefined
+      this.authorizationDetailsError = undefined
       const issuerDID = this.getIssuerForType(this.selectedCredentialType)
       if (!issuerDID) {
         this.issueError = 'No issuer found for selected credential type'
@@ -104,6 +118,17 @@ export default {
         return
       }
 
+      let parsedAuthorizationDetails
+      const trimmedAuthorizationDetails = this.authorizationDetails.trim()
+      if (trimmedAuthorizationDetails) {
+        try {
+          parsedAuthorizationDetails = JSON.parse(trimmedAuthorizationDetails)
+        } catch (e) {
+          this.authorizationDetailsError = 'Invalid JSON: ' + e.message
+          return
+        }
+      }
+
       const redirectUri = `${window.location.origin}${window.location.pathname}${this.$router.resolve({name: 'admin.identityDetails', params: {subjectID: this.subjectID}}).href}`
 
       const requestBody = {
@@ -111,6 +136,9 @@ export default {
         issuer: issuerDID,
         wallet_did: this.selectedWalletDID,
         redirect_uri: redirectUri,
+      }
+      if (parsedAuthorizationDetails !== undefined) {
+        requestBody.authorization_details = parsedAuthorizationDetails
       }
 
       this.$api.post(`api/proxy/internal/auth/v2/${encodeURIPath(this.subjectID)}/request-credential`, requestBody)
@@ -146,6 +174,23 @@ export default {
 
 :deep(select) {
   width: 100%;
+}
+
+details {
+  margin-top: 0.5rem;
+}
+
+details > summary {
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+}
+
+details > textarea {
+  width: 100%;
+  margin-top: 0.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
 }
 </style>
 

--- a/web/src/components/ErrorMessage.vue
+++ b/web/src/components/ErrorMessage.vue
@@ -3,7 +3,7 @@
       class="appearance-none mb-2 mt-2 px-6 py-3.5 w-full text-sm text-red-500 bg-red-100 placeholder-red-500 outline-hidden border border-red-500 focus:ring-4 focus:ring-blue-200 rounded-md"
       role="alert">
     <div class="font-semibold mb-2">{{ title }}</div>
-    <div>{{ message }}</div>
+    <div><slot>{{ message }}</slot></div>
     <div v-if="showReauthenticateButton" class="mt-3">
       <button type="button"
               class="btn btn-danger"


### PR DESCRIPTION
## Summary
- Adds an expandable `<details>` section to the Request Credential modal containing a textarea for OpenID4VCI `authorization_details` JSON.
- The textarea is optional — when filled, the contents are JSON-parsed (with inline error reporting) and included in the request body as `authorization_details`; when empty, the body is unchanged.

## Test plan
- [ ] Open Request Credential form; "Authorization Details (JSON)" section is collapsed by default and expands on click.
- [ ] Submitting without any JSON works exactly as before.
- [ ] Invalid JSON shows an inline error and blocks submission.
- [ ] Valid JSON is parsed and forwarded to `/internal/auth/v2/{subjectID}/request-credential` as `authorization_details`.

Assisted by AI