### PR TITLE
Wrap long issuer DIDs in wallet credentials table

### DIFF
--- a/web/src/admin/IdentityDetails.vue
+++ b/web/src/admin/IdentityDetails.vue
@@ -87,7 +87,7 @@
           <tr v-for="credential in details.wallet_credentials" :key="credential.id"
               style="cursor: pointer">
             <td @click="$router.push({name: 'admin.credentialDetails', params: {subjectID: $route.params.subjectID, credentialID: credential.id}})">{{ credential.type.filter(t => t !== "VerifiableCredential").join(', ') }}</td>
-            <td @click="$router.push({name: 'admin.credentialDetails', params: {subjectID: $route.params.subjectID, credentialID: credential.id}})">{{ credential.issuer }}</td>
+            <td class="break-all" @click="$router.push({name: 'admin.credentialDetails', params: {subjectID: $route.params.subjectID, credentialID: credential.id}})">{{ credential.issuer }}</td>
             <td @click="$router.push({name: 'admin.credentialDetails', params: {subjectID: $route.params.subjectID, credentialID: credential.id}})">
               <span :class="statusClass(credential.status)">{{ credential.status }}</span>
             </td>


### PR DESCRIPTION
## Summary
- Long issuer values like `did:x509:...` lack natural break points and pushed the Status/Delete columns past the card boundary on the Identity Details page.
- Add `break-all` to the issuer `<td>` so the value wraps and the table fits within its section.

## Test plan
- [x] Open an identity whose wallet contains a credential with a `did:x509:...` issuer.
- [x] Confirm the issuer wraps inside the column and the Delete button is fully visible without horizontal scroll.
- [x] Confirm shorter `did:web:...` issuers still render normally.

Assisted by AI