### PR TITLE
Send authorization_details on credential request

### DIFF
--- a/web/src/admin/credentials/RequestCredential.vue
+++ b/web/src/admin/credentials/RequestCredential.vue
@@ -28,6 +28,10 @@
         <label>Issuer</label>
         <p>{{ getIssuerForType(selectedCredentialType) }}</p>
       </div>
+      <div>
+        <label for="authorization-details">Authorization Details</label>
+        <textarea v-model="authorizationDetails" id="authorization-details" rows="8"></textarea>
+      </div>
     </div>
   </modal-window>
 </template>
@@ -46,11 +50,26 @@ export default {
       issueError: undefined,
       credentialProfiles: [],
       walletDIDs: [],
+      authorizationDetails: '',
     }
   },
   computed: {
     subjectID() {
       return this.$route.params.subjectID
+    }
+  },
+  watch: {
+    selectedCredentialType(credentialType) {
+      if (!credentialType) {
+        this.authorizationDetails = ''
+        return
+      }
+      this.authorizationDetails = JSON.stringify([
+        {
+          type: 'openid_credential',
+          credential_configuration_id: credentialType,
+        },
+      ], null, 2)
     }
   },
   created() {
@@ -104,10 +123,18 @@ export default {
         return
       }
 
+      let authorizationDetails
+      try {
+        authorizationDetails = JSON.parse(this.authorizationDetails)
+      } catch (e) {
+        this.issueError = 'Invalid authorization details: ' + e.message
+        return
+      }
+
       const redirectUri = `${window.location.origin}${window.location.pathname}${this.$router.resolve({name: 'admin.identityDetails', params: {subjectID: this.subjectID}}).href}`
 
       const requestBody = {
-        credential_type: this.selectedCredentialType,
+        authorization_details: authorizationDetails,
         issuer: issuerDID,
         wallet_did: this.selectedWalletDID,
         redirect_uri: redirectUri,
@@ -146,6 +173,11 @@ export default {
 
 :deep(select) {
   width: 100%;
+}
+
+textarea {
+  width: 100%;
+  font-family: monospace;
 }
 </style>
 


### PR DESCRIPTION
## Problem

The Request Credential form posted `credential_type` to the Nuts node's `POST /internal/auth/v2/{subjectID}/request-credential` endpoint. That endpoint does **not** accept `credential_type` — per its v2 auth spec it requires `authorization_details` (RFC 9396 / OpenID4VCI 1.0 §5.1.1). The field was silently ignored and a required field was missing.

## Change

- Wrap the selected credential type in an `authorization_details` entry: `[{ type: "openid_credential", credential_configuration_id: <type> }]`.
- Expose the `authorization_details` JSON as an editable textarea, auto-filled when a credential type is selected (and cleared when deselected), so operators can adjust the payload per-request.
- Parse the textarea on submit; invalid JSON surfaces an error instead of being sent.

## Note

`credential_configuration_id` is set from the profile's `type` (`CredentialProfile.Type`). The node matches this against the issuer's `credential_configurations_supported` metadata keys, so the configured `type` must be an actual credential configuration ID. The editable textarea allows correcting this per-request.

Assisted by AI