### PR TITLE
Fix invisible modal panel (Tailwind v4 opacity syntax)

### DIFF
--- a/web/src/components/ModalWindow.vue
+++ b/web/src/components/ModalWindow.vue
@@ -12,7 +12,7 @@
           From: "opacity-100"
           To: "opacity-0"
       -->
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+      <div class="fixed inset-0 bg-gray-500/75 transition-opacity" aria-hidden="true"></div>
 
       <!-- This element is to trick the browser into centering the modal contents. -->
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>


### PR DESCRIPTION
## Problem

Every modal renders as a blank gray screen with no console errors.

The shared `ModalWindow.vue` backdrop used `bg-gray-500 bg-opacity-75`. The `bg-opacity-*` utilities were **removed in Tailwind v4** (adopted in #165), so `bg-opacity-75` generates no CSS. The `fixed inset-0` backdrop therefore renders **fully opaque** and, being a positioned element, paints on top of the static modal panel — hiding it entirely.

## Fix

Use the Tailwind v4 slash-opacity syntax: `bg-gray-500/75`.

Assisted by AI