### PR TITLE
Fix modal dismissing when clicking the panel

### DIFF
--- a/web/src/components/ModalWindow.vue
+++ b/web/src/components/ModalWindow.vue
@@ -29,7 +29,7 @@
       -->
       <div
           @click.stop
-          class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+          class="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
 
         <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <div class="sm:flex sm:items-start">


### PR DESCRIPTION
## Problem

After #306 made the modal panel visible again, clicking the panel or any of its form fields closed the modal.

The backdrop is `fixed inset-0` (a positioned element); the panel was static, so the backdrop painted **on top** of the panel and intercepted clicks. The click hit the backdrop — whose handler triggers `cancel` — instead of the panel's `@click.stop`.

## Fix

Add `relative` to the panel so it sits above the backdrop and receives clicks (matches the canonical Tailwind modal markup). One-line change in the shared `ModalWindow.vue`; applies to all modals.

Assisted by AI